### PR TITLE
Exclude template files from linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
               run: pip install yamllint
 
             - name: Lint YAML files
-              run: yamllint -c ../../yaml_lint_configuration.yaml .
+              run: yamllint -c yaml_lint_configuration.yaml .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
               run: pip install yamllint
 
             - name: Lint YAML files
-              run: yamllint -d relaxed .
+              run: yamllint -c ../../yaml_lint_configuration.yaml .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,4 @@ repos:
       rev: v1.32.0
       hooks:
           - id: yamllint
+            exclude: .*/template

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,5 @@ repos:
       rev: v1.32.0
       hooks:
           - id: yamllint
+            args: [-d relaxed]
             exclude: .*/template

--- a/yaml_lint_configuration.yaml
+++ b/yaml_lint_configuration.yaml
@@ -1,0 +1,5 @@
+---
+extends: relaxed
+
+ignore:
+    - '*./template'

--- a/yaml_lint_configuration.yaml
+++ b/yaml_lint_configuration.yaml
@@ -2,4 +2,4 @@
 extends: relaxed
 
 ignore:
-    - '*./template'
+    - .*/template


### PR DESCRIPTION
`yamllint` can't handle Helm charts - the parsing formatter dies every time it encounters a templated variable like `{{ .Chart.name }}`. This excludes files with `templates` in the path from being linted.