### PR TITLE
bugfix: adding chart suffix

### DIFF
--- a/charts/fhir-converter/Chart.yaml
+++ b/charts/fhir-converter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: fhir-converter
+name: fhir-converter-chart
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0

--- a/charts/ingestion/Chart.yaml
+++ b/charts/ingestion/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ingestion
+name: ingestion-chart
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0

--- a/charts/validation/Chart.yaml
+++ b/charts/validation/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: validation
+name: validation-chart
 description: A Helm chart for the DIBBs Validation Service
 type: application
 version: 0.1.0


### PR DESCRIPTION
To keep the names consistent, all charts should have `-chart` at the end 