### PR TITLE
Add ingress controller charts, swap load balancers to clusterIPs

### DIFF
--- a/charts/alerts/templates/service.yaml
+++ b/charts/alerts/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-alerts-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/fhir-converter/templates/service.yaml
+++ b/charts/fhir-converter/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-fhir-converter-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/ingestion/templates/service.yaml
+++ b/charts/ingestion/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-ingestion-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/ingress/ingress.yaml
+++ b/charts/ingress/ingress.yaml
@@ -17,44 +17,44 @@ spec:
                 port:
                   number: 8080
           - path: /alerts/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: alerts-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: alerts-service
+                port:
+                  number: 8080
           - path: /fhir-converter/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: fhir-converter-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: fhir-converter-service
+                port:
+                  number: 8080
           - path: /message-parser/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: message-parser-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: message-parser-service
+                port:
+                  number: 8080
           - path: /record-linkage/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: record-linkage-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: record-linkage-service
+                port:
+                  number: 8080
           - path: /tabulation/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: tabulation-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: tabulation-service
+                port:
+                  number: 8080
           - path: /validation/*
-              pathType: Prefix
-              backend:
-                service:
-                  name: validation-service
-                  port:
-                    number: 8080
+            pathType: Prefix
+            backend:
+              service:
+                name: validation-service
+                port:
+                  number: 8080

--- a/charts/ingress/ingress.yaml
+++ b/charts/ingress/ingress.yaml
@@ -13,48 +13,48 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: ingestion-service
+                name: phdi-{env}-ingestion-service
                 port:
                   number: 8080
           - path: /alerts/*
             pathType: Prefix
             backend:
               service:
-                name: alerts-service
+                name: phdi-{env}-alerts-service
                 port:
                   number: 8080
           - path: /fhir-converter/*
             pathType: Prefix
             backend:
               service:
-                name: fhir-converter-service
+                name: phdi-{env}-fhir-converter-service
                 port:
                   number: 8080
           - path: /message-parser/*
             pathType: Prefix
             backend:
               service:
-                name: message-parser-service
+                name: phdi-{env}-message-parser-service
                 port:
                   number: 8080
           - path: /record-linkage/*
             pathType: Prefix
             backend:
               service:
-                name: record-linkage-service
+                name: phdi-{env}-record-linkage-service
                 port:
                   number: 8080
           - path: /tabulation/*
             pathType: Prefix
             backend:
               service:
-                name: tabulation-service
+                name: phdi-{env}-tabulation-service
                 port:
                   number: 8080
           - path: /validation/*
             pathType: Prefix
             backend:
               service:
-                name: validation-service
+                name: phdi-{env}-validation-service
                 port:
                   number: 8080

--- a/charts/ingress/ingress.yaml
+++ b/charts/ingress/ingress.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingestion
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-path-prefix: "/"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /ingestion/*
+            pathType: Prefix
+            backend:
+              service:
+                name: ingestion-service
+                port:
+                  number: 8080
+          - path: /alerts/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: alerts-service
+                  port:
+                    number: 8080
+          - path: /fhir-converter/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: fhir-converter-service
+                  port:
+                    number: 8080
+          - path: /message-parser/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: message-parser-service
+                  port:
+                    number: 8080
+          - path: /record-linkage/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: record-linkage-service
+                  port:
+                    number: 8080
+          - path: /tabulation/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: tabulation-service
+                  port:
+                    number: 8080
+          - path: /validation/*
+              pathType: Prefix
+              backend:
+                service:
+                  name: validation-service
+                  port:
+                    number: 8080

--- a/charts/message-parser/templates/service.yaml
+++ b/charts/message-parser/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-message-parser-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/record-linkage/templates/deployment.yaml
+++ b/charts/record-linkage/templates/deployment.yaml
@@ -13,8 +13,6 @@ spec:
     metadata:
       labels:
         app: record-linkage-app
-      annotations:
-        checksum/config: {{ include (print $.Template.Basepath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/record-linkage/templates/service.yaml
+++ b/charts/record-linkage/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-record-linkage-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/tabulation/templates/service.yaml
+++ b/charts/tabulation/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-tabulation-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/charts/validation/templates/service.yaml
+++ b/charts/validation/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name}}-validation-service
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080


### PR DESCRIPTION
A new chart setting up our ingress controller. It also changes our load balancers to clusterIPs since we shouldn't need individual LBs for the services. Let me know if you have questions