### PR TITLE
Convert ingress to Helm chart

### DIFF
--- a/.github/config/cr.yml
+++ b/.github/config/cr.yml
@@ -1,1 +1,1 @@
-skip-existing: True
+skip-existing: False

--- a/.github/config/cr.yml
+++ b/.github/config/cr.yml
@@ -1,1 +1,1 @@
-skip-existing: False
+skip-existing: True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+        with:
+          version: 'latest' # default is latest (stable)
+          token: ${{ secrets.GITHUB_TOKEN }} # only needed if version is 'latest'
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/charts/alerts/Chart.yaml
+++ b/charts/alerts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alerts-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0.8"

--- a/charts/alerts/Chart.yaml
+++ b/charts/alerts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alerts-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.0.8"

--- a/charts/alerts/templates/service.yaml
+++ b/charts/alerts/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-alerts-service
+  name: alerts-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/fhir-converter/Chart.yaml
+++ b/charts/fhir-converter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fhir-converter-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.16.0"

--- a/charts/fhir-converter/Chart.yaml
+++ b/charts/fhir-converter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fhir-converter-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.16.0"

--- a/charts/fhir-converter/templates/service.yaml
+++ b/charts/fhir-converter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-fhir-converter-service
+  name: fhir-converter-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/ingestion/Chart.yaml
+++ b/charts/ingestion/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ingestion-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.16.0"

--- a/charts/ingestion/Chart.yaml
+++ b/charts/ingestion/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ingestion-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.16.0"

--- a/charts/ingestion/templates/service.yaml
+++ b/charts/ingestion/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-ingestion-service
+  name: ingestion-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/ingress/.helmignore
+++ b/charts/ingress/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ingress-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.16.0"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ingress-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ingress-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.16.0"

--- a/charts/ingress/templates/ingress.yaml
+++ b/charts/ingress/templates/ingress.yaml
@@ -10,7 +10,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingressHostname }}
-      secretName: phdi-playground-issuer-account-key-prod
+      secretName: phdi-playground-issuer-account-key
   rules:
     - host: {{ .Values.ingressHostname }}
       http:

--- a/charts/ingress/templates/ingress.yaml
+++ b/charts/ingress/templates/ingress.yaml
@@ -5,9 +5,15 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/backend-path-prefix: "/"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingressHostname }}
+      secretName: phdi-playground-issuer-account-key-prod
   rules:
-    - http:
+    - host: {{ .Values.ingressHostname }}
+      http:
         paths:
           - path: /ingestion/*
             pathType: Prefix

--- a/charts/ingress/templates/ingress.yaml
+++ b/charts/ingress/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingestion
+  name: ingress
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/backend-path-prefix: "/"
@@ -13,48 +13,48 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-ingestion-service
+                name: ingestion-service
                 port:
                   number: 8080
           - path: /alerts/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-alerts-service
+                name: alerts-service
                 port:
                   number: 8080
           - path: /fhir-converter/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-fhir-converter-service
+                name: fhir-converter-service
                 port:
                   number: 8080
           - path: /message-parser/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-message-parser-service
+                name: message-parser-service
                 port:
                   number: 8080
           - path: /record-linkage/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-record-linkage-service
+                name: record-linkage-service
                 port:
                   number: 8080
           - path: /tabulation/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-tabulation-service
+                name: tabulation-service
                 port:
                   number: 8080
           - path: /validation/*
             pathType: Prefix
             backend:
               service:
-                name: phdi-{env}-validation-service
+                name: validation-service
                 port:
                   number: 8080

--- a/charts/message-parser/Chart.yaml
+++ b/charts/message-parser/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: message-parser-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0.9"

--- a/charts/message-parser/Chart.yaml
+++ b/charts/message-parser/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: message-parser-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.0.9"

--- a/charts/message-parser/templates/service.yaml
+++ b/charts/message-parser/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-message-parser-service
+  name: message-parser-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/record-linkage/Chart.yaml
+++ b/charts/record-linkage/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: record-linkage-chart
 description: A Helm Chart for the DIBBs Record Linkage Service
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0.8"
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg

--- a/charts/record-linkage/Chart.yaml
+++ b/charts/record-linkage/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: record-linkage-chart
 description: A Helm Chart for the DIBBs Record Linkage Service
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.0.8"
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg

--- a/charts/record-linkage/templates/service.yaml
+++ b/charts/record-linkage/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-record-linkage-service
+  name: record-linkage-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/tabulation/Chart.yaml
+++ b/charts/tabulation/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tabulation-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "1.0.8"

--- a/charts/tabulation/Chart.yaml
+++ b/charts/tabulation/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tabulation-chart
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0.8"

--- a/charts/tabulation/templates/service.yaml
+++ b/charts/tabulation/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-tabulation-service
+  name: tabulation-service
 spec:
   type: ClusterIP
   ports:

--- a/charts/validation/Chart.yaml
+++ b/charts/validation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: validation-chart
 description: A Helm chart for the DIBBs Validation Service
 type: application
-version: 0.1.0
+version: 0.1.5
 appVersion: "v1.0.9"
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg

--- a/charts/validation/Chart.yaml
+++ b/charts/validation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: validation-chart
 description: A Helm chart for the DIBBs Validation Service
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "v1.0.9"
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg

--- a/charts/validation/templates/service.yaml
+++ b/charts/validation/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-validation-service
+  name: validation-service
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
This removes the release/env name from the services so that we can reference them without interpolation (they are already inside a cluster with the environment name anyways)

Also attempting to fix the issue with the release workflow.

Also adds the TLS config needed for [this PR in phdi-playground](https://github.com/CDCgov/phdi-playground/pull/7)