### PR TITLE
Orchestration Chart Renaming

### DIFF
--- a/charts/ingress/templates/ingress.yaml
+++ b/charts/ingress/templates/ingress.yaml
@@ -1,66 +1,74 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress
-  annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
-    appgw.ingress.kubernetes.io/backend-path-prefix: "/"
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    name: ingress
+    annotations:
+        kubernetes.io/ingress.class: azure/application-gateway
+        appgw.ingress.kubernetes.io/backend-path-prefix: /
+        cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
-  tls:
-    - hosts:
-        - {{ .Values.ingressHostname }}
-      secretName: phdi-playground-issuer-account-key
-  rules:
-    - host: {{ .Values.ingressHostname }}
-      http:
-        paths:
-          - path: /ingestion/*
-            pathType: Prefix
-            backend:
-              service:
-                name: ingestion-service
-                port:
-                  number: 8080
-          - path: /alerts/*
-            pathType: Prefix
-            backend:
-              service:
-                name: alerts-service
-                port:
-                  number: 8080
-          - path: /fhir-converter/*
-            pathType: Prefix
-            backend:
-              service:
-                name: fhir-converter-service
-                port:
-                  number: 8080
-          - path: /message-parser/*
-            pathType: Prefix
-            backend:
-              service:
-                name: message-parser-service
-                port:
-                  number: 8080
-          - path: /record-linkage/*
-            pathType: Prefix
-            backend:
-              service:
-                name: record-linkage-service
-                port:
-                  number: 8080
-          - path: /tabulation/*
-            pathType: Prefix
-            backend:
-              service:
-                name: tabulation-service
-                port:
-                  number: 8080
-          - path: /validation/*
-            pathType: Prefix
-            backend:
-              service:
-                name: validation-service
-                port:
-                  number: 8080
+    tls:
+        - hosts:
+              - {{.Values.ingressHostname: null}: null}
+          secretName: phdi-playground-issuer-account-key
+    rules:
+        - host: {{.Values.ingressHostname: null}: null}
+          http:
+              paths:
+                  - path: /ingestion/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: ingestion-service
+                            port:
+                                number: 8080
+                  - path: /alerts/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: alerts-service
+                            port:
+                                number: 8080
+                  - path: /fhir-converter/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: fhir-converter-service
+                            port:
+                                number: 8080
+                  - path: /message-parser/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: message-parser-service
+                            port:
+                                number: 8080
+                  - path: /record-linkage/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: record-linkage-service
+                            port:
+                                number: 8080
+                  - path: /tabulation/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: tabulation-service
+                            port:
+                                number: 8080
+                  - path: /validation/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: validation-service
+                            port:
+                                number: 8080
+                  - path: /orchestration/*
+                    pathType: Prefix
+                    backend:
+                        service:
+                            name: orchestration-service
+                            port:
+                                number: 8080

--- a/charts/orchestration/Chart.yaml
+++ b/charts/orchestration/Chart.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: v2
-name: orchestration-chart
+name: orchestration
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.6
-appVersion: "1.16.0"
+appVersion: 1.16.0
 

--- a/charts/orchestration/templates/deployment.yaml
+++ b/charts/orchestration/templates/deployment.yaml
@@ -1,62 +1,62 @@
-﻿---
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{.Release.Name }}-orchestration-app"
-  labels:
-    app: orchestration-app
-spec:
-  replicas: {{.Values.replicaCount}}
-  selector:
-    matchLabels:
-      app: orchestration-app
-  template:
-    metadata:
-      annotations:
-      labels:
+    name: '{{.Release.Name }}-orchestration-app'
+    labels:
         app: orchestration-app
-    spec:
-      imagePullSecrets:
-      containers:
-        - name: {{.Chart.Name}}
-          image: ghcr.io/cdcgov/phdi/orchestration:{{ .Values.image.tag }}
-          imagePullPolicy: {{.Values.image.pullPolicy}}
-          ports:
-            - name: {{.Chart.Name | trunc 14}}
-              containerPort: {{.Values.service.port}}
-          env:
-            - name: ALERTS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: alerts-url
-            - name: FHIR_CONVERTER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: fhir-converter-url
-            - name: INGESTION_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: ingestion-url
-            - name: MESSAGE_PARSER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: message-parser-url
-            - name: RECORD_LINKAGE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: record-linkage-url
-            - name: TABULATION_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: tabulation-url
-            - name: VALIDATION_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{.Release.Name}}-orchestration-secrets"
-                  key: validation-url
+spec:
+    replicas: {{.Values.replicaCount: null}: null}
+    selector:
+        matchLabels:
+            app: orchestration-app
+    template:
+        metadata:
+            annotations:
+            labels:
+                app: orchestration-app
+        spec:
+            imagePullSecrets:
+            containers:
+                - name: {{.Chart.Name: null}: null}
+                  image: ghcr.io/cdcgov/phdi/orchestration:{{ .Values.image.tag }}
+                  imagePullPolicy: {{.Values.image.pullPolicy: null}: null}
+                  ports:
+                      - name: {{.Chart.Name | trunc 14: null}: null}
+                        containerPort: {{.Values.service.port: null}: null}
+                  env:
+                      - name: ALERTS_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: alerts-url
+                      - name: FHIR_CONVERTER_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: fhir-converter-url
+                      - name: INGESTION_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: ingestion-url
+                      - name: MESSAGE_PARSER_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: message-parser-url
+                      - name: RECORD_LINKAGE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: record-linkage-url
+                      - name: TABULATION_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: tabulation-url
+                      - name: VALIDATION_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: '{{.Release.Name}}-orchestration-secrets'
+                                key: validation-url

--- a/charts/orchestration/templates/secrets.yaml
+++ b/charts/orchestration/templates/secrets.yaml
@@ -1,14 +1,15 @@
-﻿apiVersion: v1
+---
+apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{.Release.Name}}-orchestration-secrets"
+    name: '{{.Release.Name}}-orchestration-secrets'
 type: Opaque
 stringData:
-  alerts-url: "{{ .Values.alertsUrl | quote }}"
-  fhir-converter-url: "{{ .Values.fhirConverterUrl | quote }}"
-  ingestion-url: "{{ .Values.ingestionUrl | quote }}"
-  ingress-url: "{{ .Values.ingressUrl | quote }}"
-  message-parser-url: "{{ .Values.message-parserUrl | quote }}"
-  record-linkage-url: "{{ .Values.record-linkageUrl | quote }}"
-  tabulation-url: "{{ .Values.tabulationUrl | quote }}"
-  validation-url: "{{ .Values.validationUrl | quote }}"
+    alerts-url: '{{ .Values.alertsUrl | quote }}'
+    fhir-converter-url: '{{ .Values.fhirConverterUrl | quote }}'
+    ingestion-url: '{{ .Values.ingestionUrl | quote }}'
+    ingress-url: '{{ .Values.ingressUrl | quote }}'
+    message-parser-url: '{{ .Values.messageParserUrl | quote }}'
+    record-linkage-url: '{{ .Values.recordLinkageUrl | quote }}'
+    tabulation-url: '{{ .Values.tabulationUrl | quote }}'
+    validation-url: '{{ .Values.validationUrl | quote }}'

--- a/charts/orchestration/values.yaml
+++ b/charts/orchestration/values.yaml
@@ -1,18 +1,19 @@
+---
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cdcgov/phdi/orchestration
-  pullPolicy: IfNotPresent
-  tag: "v1.0.7"
+    repository: ghcr.io/cdcgov/phdi/orchestration
+    pullPolicy: IfNotPresent
+    tag: v1.0.14
 
 service:
-  port: 8080
+    port: 8080
 
-alerts-url: "$alertsUrl"
-fhir-converter-url: "$fhirConverterUrl"
-ingestion-url: "$ingestionUrl"
-ingress-url: "$ingressUrl"
-message-parser-url: "$messageParserUrl"
-record-linkage-url: "$recordLinkageUrl"
-tabulation-url: "$tabulationUrl"
-validation-url: "$validationUrl"
+alerts-url: $alertsUrl
+fhir-converter-url: $fhirConverterUrl
+ingestion-url: $ingestionUrl
+ingress-url: $ingressUrl
+message-parser-url: $messageParserUrl
+record-linkage-url: $recordLinkageUrl
+tabulation-url: $tabulationUrl
+validation-url: $validationUrl


### PR DESCRIPTION
# PULL REQUEST

## Summary
The default chart name was "orchestration-chart", which was being truncated at 14 chars, leaving just "orchestration-". Helm didn't like this (the chart won't install), so changing the name to just "orchestration"

[//]: # (REQUIRED)
## Related Issue
Related to [821](https://app.zenhub.com/workspaces/secret-6480bf2ee530095ab41ebbe9/issues/gh/cdcgov/phdi/821)

## Additional Information
This should unblock and allow us to install the chart on phdi-playground.

[//]: # (PR title: Remember to name your PR descriptively!)
