### PR TITLE
Standardize chart names and bump to 0.2.0

### DIFF
--- a/charts/alerts/Chart.yaml
+++ b/charts/alerts/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: alerts-chart
+name: alerts
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/ecr-viewer/Chart.yaml
+++ b/charts/ecr-viewer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ecr-viewer
 description: A Helm chart for the DIBBs eCR Viewer
 type: application
-version: 0.1.6
+version: 0.2.0

--- a/charts/fhir-converter/Chart.yaml
+++ b/charts/fhir-converter/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: fhir-converter-chart
+name: fhir-converter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/ingestion/Chart.yaml
+++ b/charts/ingestion/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: ingestion-chart
+name: ingestion
 description: A Helm chart for the DIBBs ingestion service
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: ingress-chart
+name: ingress
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.10
+version: 0.2.0

--- a/charts/message-parser/Chart.yaml
+++ b/charts/message-parser/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: message-parser-chart
+name: message-parser
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/orchestration/Chart.yaml
+++ b/charts/orchestration/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: orchestration
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.14
+version: 0.2.0

--- a/charts/record-linkage/Chart.yaml
+++ b/charts/record-linkage/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-name: rec-link-chart
+name: record-linkage
 description: A Helm Chart for the DIBBs Record Linkage Service
 type: application
-version: 0.1.8
+version: 0.2.0
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg

--- a/charts/tabulation/Chart.yaml
+++ b/charts/tabulation/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-name: tabulation-chart
+name: tabulation
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/tefca-viewer/Chart.yaml
+++ b/charts/tefca-viewer/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tefca-viewer
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.2.0

--- a/charts/validation/Chart.yaml
+++ b/charts/validation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-name: validation-chart
+name: validation
 description: A Helm chart for the DIBBs Validation Service
 type: application
-version: 0.1.7
+version: 0.2.0
 icon: https://commons.wikimedia.org/wiki/File:US_CDC_logo.svg


### PR DESCRIPTION
# PULL REQUEST

## Summary
Let's remove `-chart` from all the chart names to keep it standard. I also bumped every chart to version 0.2.0 so we can start fresh at a consistent version.

