### PR TITLE
update tefca-viewer port to 3000

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,5 +47,10 @@ jobs:
             - name: Create kind cluster
               uses: helm/kind-action@v1.7.0
 
+            - name: Extract branch name
+              shell: bash
+              run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+              id: extract_branch
+
             - name: Upgrade and Test All Charts
-              run: ct install --all --target-branch ${{ github.event.repository.default_branch}}
+              run: ct install --all --target-branch ${{ steps.extract_branch.outputs.branch }}

--- a/charts/tefca-viewer/Chart.yaml
+++ b/charts/tefca-viewer/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: tefca-viewer
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/tefca-viewer/templates/service.yaml
+++ b/charts/tefca-viewer/templates/service.yaml
@@ -7,7 +7,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{.Values.service.port}}
-      targetPort: 8080
+      targetPort: 3000
       protocol: TCP
   selector:
     app: {{.Values.appName}}

--- a/charts/tefca-viewer/templates/tests/test-connection.yaml
+++ b/charts/tefca-viewer/templates/tests/test-connection.yaml
@@ -12,6 +12,6 @@ spec:
       image: busybox
       command: ["wget"]
       args: [
-        "{{.Release.Name}}-{{.Values.serviceName}}:{{ .Values.service.port}}"
+        "{{.Release.Name}}-{{.Values.serviceName}}:{{ .Values.service.port}}/tefca-viewer"
       ]
   restartPolicy: Never

--- a/charts/tefca-viewer/values.yaml
+++ b/charts/tefca-viewer/values.yaml
@@ -3,8 +3,8 @@ replicaCount: 1
 
 image:
     repository: ghcr.io/cdcgov/phdi/tefca-viewer
-    pullPolicy: IfNotPresent
-    tag: v1.2.7
+    pullPolicy: Always
+    tag: dev
 
 service:
     port: 3000

--- a/charts/tefca-viewer/values.yaml
+++ b/charts/tefca-viewer/values.yaml
@@ -7,7 +7,7 @@ image:
     tag: v1.2.7
 
 service:
-    port: 8080
+    port: 3000
 
 name: tefca-viewer
 appName: tefca-viewer-app


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR aims to accomplish two things:

1. Support the migration of the TEFCA Viewer from Python/HTMX to TypeScript/NextJs/React we update ports from `8080` to `3000`.
2. In order to allow rapid deployments of the current progress of the TEFCA Viewer we change the target tag to `dev` and the pull policy to `Always`. This will let us rapidly deploy changes for user testing in the connectathon environment, but we will need to roll these in the future when the app is more stable.

[//]: # (REQUIRED)
## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
