### PR TITLE
Create message refiner helm chart

### DIFF
--- a/charts/message-refiner/.helmignore
+++ b/charts/message-refiner/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/message-refiner/Chart.yaml
+++ b/charts/message-refiner/Chart.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v2
+name: message-refiner
+description: A Helm chart for Kubernetes
+type: application
+version: 0.2.0

--- a/charts/message-refiner/templates/NOTES.txt
+++ b/charts/message-refiner/templates/NOTES.txt
@@ -1,0 +1,4 @@
+ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+       You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ .Release.Name }}-message-refiner'
+export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-message-refiner)
+echo http://$SERVICE_IP:{{ .Values.service.port }}

--- a/charts/message-refiner/templates/deployment.yaml
+++ b/charts/message-refiner/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{.Release.Name}}-{{.Values.appName}}"
+  labels:
+    app: {{.Values.appName}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: {{.Values.appName}}
+  template:
+    metadata:
+      annotations:
+      labels:
+        app: {{.Values.appName}}
+    spec:
+      imagePullSecrets:
+      containers:
+        - name: {{.Chart.Name}}
+          image: ghcr.io/cdcgov/phdi/{{.Values.name}}:{{ .Values.image.tag }}
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          ports:
+            - name: {{.Chart.Name | trunc 14}}
+              containerPort: {{.Values.service.port}}
+          env:
+            - name: TCR_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{.Release.Name}}-message-refiner-secrets"
+                  key: tcr-url

--- a/charts/message-refiner/templates/secrets.yaml
+++ b/charts/message-refiner/templates/secrets.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: '{{.Release.Name}}-message-refiner-secrets'
+type: Opaque
+stringData:
+    tcr-url: {{ .Values.tcrUrl | quote }}

--- a/charts/message-refiner/templates/service.yaml
+++ b/charts/message-refiner/templates/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{.Release.Name}}-{{.Values.serviceName}}"
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: {{.Values.appName}}

--- a/charts/message-refiner/templates/tests/test-connection.yaml
+++ b/charts/message-refiner/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{.Release.Name}}-{{.Values.name}}-test"
+  labels:
+    app: "{{.Values.appName}}"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ["wget"]
+      args: [
+        "{{.Release.Name}}-{{.Values.serviceName}}:{{ .Values.service.port}}"
+      ]
+  restartPolicy: Never

--- a/charts/message-refiner/values.yaml
+++ b/charts/message-refiner/values.yaml
@@ -1,0 +1,15 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cdcgov/phdi/message-refiner
+  pullPolicy: IfNotPresent
+  tag: v1.4.0
+
+service:
+  port: 8080
+
+name: "message-refiner"
+appName: "message-refiner-app"
+serviceName: "message-refiner-service"
+
+tcrURL: $tcrUrl


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR creates a helm chart for the message-refiner service, using the existing charts as a template. To be fully operational, this chart will eventually require a terraform update to PHDI playground to include the TCR URL as an environment variable.

## Related Issue
https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/1899

