### PR TITLE
Updating values.yaml to read latest version for all charts

### DIFF
--- a/charts/alerts/values.yaml
+++ b/charts/alerts/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/alerts
   pullPolicy: IfNotPresent
-  tag: v1.2.1
+  tag: latest
 
 service:
   port: 8080

--- a/charts/alerts/values.yaml
+++ b/charts/alerts/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/alerts
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/alerts/values.yaml
+++ b/charts/alerts/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/alerts
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/ecr-viewer/values.yaml
+++ b/charts/ecr-viewer/values.yaml
@@ -4,7 +4,6 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/ecr-viewer
     pullPolicy: IfNotPresent
-    dockerTag: latest
 
 service:
     port: 3000

--- a/charts/ecr-viewer/values.yaml
+++ b/charts/ecr-viewer/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/ecr-viewer
     pullPolicy: IfNotPresent
-    tag: latest
+    dockerTag: latest
 
 service:
     port: 3000

--- a/charts/ecr-viewer/values.yaml
+++ b/charts/ecr-viewer/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/ecr-viewer
     pullPolicy: IfNotPresent
-    tag: v1.2.1
+    tag: latest
 
 service:
     port: 3000

--- a/charts/fhir-converter/values.yaml
+++ b/charts/fhir-converter/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/fhir-converter
     pullPolicy: IfNotPresent
-    tag: v1.2.1
+    tag: latest
 
 service:
     port: 8080

--- a/charts/fhir-converter/values.yaml
+++ b/charts/fhir-converter/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/fhir-converter
     pullPolicy: IfNotPresent
-    tag: latest
+    dockerTag: latest
 
 service:
     port: 8080

--- a/charts/fhir-converter/values.yaml
+++ b/charts/fhir-converter/values.yaml
@@ -4,7 +4,6 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/fhir-converter
     pullPolicy: IfNotPresent
-    dockerTag: latest
 
 service:
     port: 8080

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/ingestion
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/ingestion
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/ingestion/values.yaml
+++ b/charts/ingestion/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/ingestion
   pullPolicy: IfNotPresent
-  tag: v1.2.1
+  tag: latest
 
 service:
   port: 8080

--- a/charts/message-parser/values.yaml
+++ b/charts/message-parser/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-parser
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/message-parser/values.yaml
+++ b/charts/message-parser/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-parser
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/message-parser/values.yaml
+++ b/charts/message-parser/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-parser
   pullPolicy: IfNotPresent
-  tag: v1.2.1
+  tag: latest
 
 service:
   port: 8080

--- a/charts/message-refiner/values.yaml
+++ b/charts/message-refiner/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-refiner
   pullPolicy: IfNotPresent
-  tag: v1.4.4
+  tag: latest
 
 service:
   port: 8080

--- a/charts/message-refiner/values.yaml
+++ b/charts/message-refiner/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-refiner
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/message-refiner/values.yaml
+++ b/charts/message-refiner/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/message-refiner
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/orchestration/values.yaml
+++ b/charts/orchestration/values.yaml
@@ -4,7 +4,6 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/orchestration
     pullPolicy: IfNotPresent
-    dockerTag: latest
 
 service:
     port: 8080

--- a/charts/orchestration/values.yaml
+++ b/charts/orchestration/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/orchestration
     pullPolicy: IfNotPresent
-    tag: v1.2.1
+    tag: latest
 
 service:
     port: 8080

--- a/charts/orchestration/values.yaml
+++ b/charts/orchestration/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ghcr.io/cdcgov/phdi/orchestration
     pullPolicy: IfNotPresent
-    tag: latest
+    dockerTag: latest
 
 service:
     port: 8080

--- a/charts/record-linkage/values.yaml
+++ b/charts/record-linkage/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ngnix
     pullPolicy: IfNotPresent
-    tag: latest
+    dockerTag: latest
 
 service:
     port: 80

--- a/charts/record-linkage/values.yaml
+++ b/charts/record-linkage/values.yaml
@@ -4,7 +4,6 @@ replicaCount: 1
 image:
     repository: ngnix
     pullPolicy: IfNotPresent
-    dockerTag: latest
 
 service:
     port: 80

--- a/charts/record-linkage/values.yaml
+++ b/charts/record-linkage/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
     repository: ngnix
     pullPolicy: IfNotPresent
-    tag: v1.0.9
+    tag: latest
 
 service:
     port: 80

--- a/charts/tabulation/values.yaml
+++ b/charts/tabulation/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/tabulation
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/tabulation/values.yaml
+++ b/charts/tabulation/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/tabulation
   pullPolicy: IfNotPresent
-  tag: v1.2.1
+  tag: latest
 
 service:
   port: 8080

--- a/charts/tabulation/values.yaml
+++ b/charts/tabulation/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/tabulation
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/trigger-code-reference/values.yaml
+++ b/charts/trigger-code-reference/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/trigger-code-reference
   pullPolicy: IfNotPresent
-  tag: latest
+  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/trigger-code-reference/values.yaml
+++ b/charts/trigger-code-reference/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/trigger-code-reference
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 8080

--- a/charts/trigger-code-reference/values.yaml
+++ b/charts/trigger-code-reference/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/trigger-code-reference
   pullPolicy: IfNotPresent
-  tag: v1.4.1
+  tag: latest
 
 service:
   port: 8080

--- a/charts/validation/values.yaml
+++ b/charts/validation/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/validation
   pullPolicy: IfNotPresent
-  tag: v1.2.1
+  dockerTag: latest
 
 service:
   port: 80

--- a/charts/validation/values.yaml
+++ b/charts/validation/values.yaml
@@ -9,7 +9,6 @@ replicaCount: 1
 image:
   repository: ghcr.io/cdcgov/phdi/validation
   pullPolicy: IfNotPresent
-  dockerTag: latest
 
 service:
   port: 80


### PR DESCRIPTION
# PULL REQUEST

## Summary
This changes all charts to take the latest version of the docker image. They had previously been hardcoded and in many cases were out of date.

[//]: # (REQUIRED)
## Related Issue
Fixes #1932

## Additional Information
I did not change tefca-viewer because there were convos I had with Dan about wanted to keep in on the dev image to allow quicker deploys as they do demos this week.

[//]: # (PR title: Remember to name your PR descriptively!)
