### PR TITLE
Point TEFCA Viewer chart to new repo

### DIFF
--- a/charts/tefca-viewer/values.yaml
+++ b/charts/tefca-viewer/values.yaml
@@ -2,9 +2,9 @@
 replicaCount: 1
 
 image:
-    repository: ghcr.io/cdcgov/phdi/tefca-viewer
+    repository: ghcr.io/cdcgov/dibbs-query-connector/query-connector
     pullPolicy: Always
-    tag: dev
+    tag: latest
 
 service:
     port: 3000


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR moves us over to using the container images for the TEFCA Viewer produced on the `dibbs-query-connector` repository.

[//]: # (REQUIRED)
## Related Issue
Fixes #

## Additional Information
Anything else the review team should know?

[//]: # (PR title: Remember to name your PR descriptively!)
